### PR TITLE
Add priceRange and url to LocalBusiness

### DIFF
--- a/src/ContextTypes/LocalBusiness.php
+++ b/src/ContextTypes/LocalBusiness.php
@@ -20,6 +20,8 @@ class LocalBusiness extends AbstractContext
         'geo' => GeoCoordinates::class,
         'review' => Review::class,
         'aggregateRating' => AggregateRating::class,
+        'url' => null,
+        'priceRange' => null,
     ];
 
     /**


### PR DESCRIPTION
I'm having some warnings in Google Structure Validator about having priceRange and url in the LocalBusiness structure. 

Could it be possible to have this two items added to LocalBusiness?