### PR TITLE
Allow an Organisation to have multiple ContactPoints

### DIFF
--- a/src/ContextTypes/Organization.php
+++ b/src/ContextTypes/Organization.php
@@ -26,4 +26,26 @@ class Organization extends Thing
         parent::__construct($attributes, array_merge($this->structure, $this->extendedStructure, $extendedStructure));
     }
 
+	/**
+	 * Set the contactPoints
+	 *
+	 * @param array $items
+	 * @return array
+	 */
+	protected function setContactPointAttribute($items)
+	{
+		if (is_array($items) === false) {
+			return $items;
+		}
+
+		//Check if it is an array with one dimension
+		if (is_array(reset($items)) === false) {
+			return $this->getNestedContext(ContactPoint::class, $items);
+		}
+
+		//Process multi dimensional array
+		return array_map(function ($item) {
+			return $this->getNestedContext(ContactPoint::class, $item);
+		}, $items);
+	}
 }

--- a/src/ContextTypes/Organization.php
+++ b/src/ContextTypes/Organization.php
@@ -26,26 +26,26 @@ class Organization extends Thing
         parent::__construct($attributes, array_merge($this->structure, $this->extendedStructure, $extendedStructure));
     }
 
-	/**
-	 * Set the contactPoints
-	 *
-	 * @param array $items
-	 * @return array
-	 */
-	protected function setContactPointAttribute($items)
-	{
-		if (is_array($items) === false) {
-			return $items;
-		}
+    /**
+     * Set the contactPoints
+     *
+     * @param array $items
+     * @return array
+     */
+    protected function setContactPointAttribute($items)
+    {
+        if (is_array($items) === false) {
+            return $items;
+        }
 
-		//Check if it is an array with one dimension
-		if (is_array(reset($items)) === false) {
-			return $this->getNestedContext(ContactPoint::class, $items);
-		}
+        //Check if it is an array with one dimension
+        if (is_array(reset($items)) === false) {
+            return $this->getNestedContext(ContactPoint::class, $items);
+        }
 
-		//Process multi dimensional array
-		return array_map(function ($item) {
-			return $this->getNestedContext(ContactPoint::class, $item);
-		}, $items);
-	}
+        //Process multi dimensional array
+        return array_map(function ($item) {
+            return $this->getNestedContext(ContactPoint::class, $item);
+        }, $items);
+    }
 }

--- a/tests/ContextTypes/Organization2ContactsTest.php
+++ b/tests/ContextTypes/Organization2ContactsTest.php
@@ -4,7 +4,7 @@ namespace JsonLd\Test\ContextTypes;
 
 use JsonLd\Test\TestCase;
 
-class OrganizationTest extends TestCase
+class Organization2ContactsTest extends TestCase
 {
     protected $class = \JsonLd\ContextTypes\Organization::class;
 
@@ -19,38 +19,34 @@ class OrganizationTest extends TestCase
         ],
         'logo' => 'https://google.com/thumbnail1.jpg',
         'contactPoint' => [
-            'telephone' => '18009999999',
+        	['@type' => 'contactPoint',
+            'telephone' => '18008888888',
             'contactType' => 'customer service',
+			],
+        	['@type' => 'contactPoint',
+            'telephone' => '18009999999',
+            'contactType' => 'sales',
+			],
         ],
     ];
 
     /**
      * @test
      */
-    public function shouldHaveContactPointObject()
+    public function shouldHave2ContactsArray()
     {
         $context = $this->make();
 
-        $this->assertEquals([
-            '@type' => 'ContactPoint',
-            'telephone' => '18009999999',
-            'contactType' => 'customer service',
-        ], $context->getProperty('contactPoint'));
+	    $this->assertEquals([
+		    '@type' => 'ContactPoint',
+		    'telephone' => '18008888888',
+		    'contactType' => 'customer service',
+	    ], $context->getProperty('contactPoint')[0]);
+	    $this->assertEquals([
+		    '@type' => 'ContactPoint',
+		    'telephone' => '18009999999',
+		    'contactType' => 'sales',
+	    ], $context->getProperty('contactPoint')[1]);
     }
 
-	/**
-	 * @test
-	 */
-	public function shouldHaveAddressArray()
-	{
-		$context = $this->make();
-
-		$this->assertEquals([
-			'@type' => 'PostalAddress',
-			'streetAddress' => '112 Apple St.',
-			'addressLocality' => 'Hamden',
-			'addressRegion' => 'CT',
-			'postalCode' => '06514',
-		], $context->getProperty('address'));
-    }
 }

--- a/tests/ContextTypes/Organization2ContactsTest.php
+++ b/tests/ContextTypes/Organization2ContactsTest.php
@@ -19,14 +19,14 @@ class Organization2ContactsTest extends TestCase
         ],
         'logo' => 'https://google.com/thumbnail1.jpg',
         'contactPoint' => [
-        	['@type' => 'contactPoint',
+            ['@type' => 'contactPoint',
             'telephone' => '18008888888',
             'contactType' => 'customer service',
-			],
-        	['@type' => 'contactPoint',
+            ],
+            ['@type' => 'contactPoint',
             'telephone' => '18009999999',
             'contactType' => 'sales',
-			],
+            ],
         ],
     ];
 
@@ -37,16 +37,15 @@ class Organization2ContactsTest extends TestCase
     {
         $context = $this->make();
 
-	    $this->assertEquals([
-		    '@type' => 'ContactPoint',
-		    'telephone' => '18008888888',
-		    'contactType' => 'customer service',
-	    ], $context->getProperty('contactPoint')[0]);
-	    $this->assertEquals([
-		    '@type' => 'ContactPoint',
-		    'telephone' => '18009999999',
-		    'contactType' => 'sales',
-	    ], $context->getProperty('contactPoint')[1]);
+        $this->assertEquals([
+            '@type' => 'ContactPoint',
+            'telephone' => '18008888888',
+            'contactType' => 'customer service',
+        ], $context->getProperty('contactPoint')[0]);
+        $this->assertEquals([
+            '@type' => 'ContactPoint',
+            'telephone' => '18009999999',
+            'contactType' => 'sales',
+        ], $context->getProperty('contactPoint')[1]);
     }
-
 }

--- a/tests/ContextTypes/OrganizationTest.php
+++ b/tests/ContextTypes/OrganizationTest.php
@@ -38,19 +38,19 @@ class OrganizationTest extends TestCase
         ], $context->getProperty('contactPoint'));
     }
 
-	/**
-	 * @test
-	 */
-	public function shouldHaveAddressArray()
-	{
-		$context = $this->make();
+    /**
+     * @test
+     */
+    public function shouldHaveAddressArray()
+    {
+        $context = $this->make();
 
-		$this->assertEquals([
-			'@type' => 'PostalAddress',
-			'streetAddress' => '112 Apple St.',
-			'addressLocality' => 'Hamden',
-			'addressRegion' => 'CT',
-			'postalCode' => '06514',
-		], $context->getProperty('address'));
+        $this->assertEquals([
+            '@type' => 'PostalAddress',
+            'streetAddress' => '112 Apple St.',
+            'addressLocality' => 'Hamden',
+            'addressRegion' => 'CT',
+            'postalCode' => '06514',
+        ], $context->getProperty('address'));
     }
 }


### PR DESCRIPTION
Added support for multiple ContactPoints with an Organisation. According to Google this should be possible: https://developers.google.com/search/docs/data-types/corporate-contact 

Also added a unit test to cover the Address of an Organisation