### PR TITLE
Base LocalBusiness type on Organization and Place type

### DIFF
--- a/src/ContextTypes/LocalBusiness.php
+++ b/src/ContextTypes/LocalBusiness.php
@@ -2,29 +2,33 @@
 
 namespace JsonLd\ContextTypes;
 
-class LocalBusiness extends AbstractContext
+class LocalBusiness extends Organization
 {
     /**
      * Property structure
      *
      * @var array
      */
-    protected $structure = [
-        'name' => null,
-        'description' => null,
-        'image' => null,
-        'telephone' => null,
-        'email' => null,
+    protected $extendedStructure = [
         'openingHours' => null,
-        'address' => PostalAddress::class,
-        'geo' => GeoCoordinates::class,
-        'review' => Review::class,
-        'aggregateRating' => AggregateRating::class,
-        'url' => null,
         'priceRange' => null,
-        'areaServed' => null,
-        'hasMap' => null,
     ];
+
+    /**
+     * Constructor. Merges extendedStructure up
+     *
+     * @param array $attributes
+     * @param array $extendedStructure
+     */
+    public function __construct(array $attributes, array $extendedStructure = [])
+    {
+        $place = new Place([]);
+        $extendedStructure = array_merge($extendedStructure, $place->structure);
+
+        parent::__construct(
+            $attributes, array_merge($this->structure, $this->extendedStructure, $extendedStructure)
+        );
+    }
 
     /**
      * Set the opening hours of the business.

--- a/src/ContextTypes/Organization.php
+++ b/src/ContextTypes/Organization.php
@@ -14,6 +14,10 @@ class Organization extends Thing
         'logo' => ImageObject::class,
         'contactPoint' => ContactPoint::class,
         'email' => null,
+        'telephone' => null,
+        'review' => Review::class,
+        'aggregateRating' => AggregateRating::class,
+        'areaServed' => null,
     ];
 
     /**

--- a/src/ContextTypes/Place.php
+++ b/src/ContextTypes/Place.php
@@ -13,6 +13,8 @@ class Place extends Thing
         'address' => PostalAddress::class,
         'review' => Review::class,
         'aggregateRating' => AggregateRating::class,
+        'geo' => GeoCoordinates::class,
+        'hasMap' => null,
     ];
 
     /**


### PR DESCRIPTION
To be conform with schema.org LocalBusiness type should extend Organization type and Place type (https://schema.org/LocalBusiness).
This will make implementation of further specific organization types much easier and consistent.